### PR TITLE
fix race condition for requestContextStore

### DIFF
--- a/context.go
+++ b/context.go
@@ -20,6 +20,9 @@ type RequestContext struct {
 // Context returns a pointer to the RequestContext for the current request.
 func Context(req *http.Request) *RequestContext {
 	cntxt, _ := requestContextStore.Load(req)
+	if cntxt == nil {
+		return nil
+	}
 	return cntxt.(*RequestContext)
 }
 

--- a/context.go
+++ b/context.go
@@ -19,7 +19,8 @@ type RequestContext struct {
 
 // Context returns a pointer to the RequestContext for the current request.
 func Context(req *http.Request) *RequestContext {
-	return requestContextStore[req]
+	cntxt, _ := requestContextStore.Load(req)
+	return cntxt.(*RequestContext)
 }
 
 // Next invokes the next HandleFunc in line registered to handle this request.

--- a/router.go
+++ b/router.go
@@ -4,13 +4,14 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 // Stores
 // ----------------------
 
 // Store to keep track of the current requestContexts in use.
-var requestContextStore = make(map[*http.Request]*RequestContext)
+var requestContextStore sync.Map // map[*http.Request]*RequestContext
 
 // Router
 // ----------------------
@@ -141,7 +142,7 @@ func (router *Router) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			// Create a RequestContext
 			cntxt := new(RequestContext)
 			// Store the requestContext
-			requestContextStore[req] = cntxt
+			requestContextStore.Store(req, cntxt)
 			// Capture the route params
 			cntxt.Params = withParams
 			// Attach the handlers to the context
@@ -152,7 +153,7 @@ func (router *Router) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			// the request is being served.
 			cntxt.Next(res, req)
 			// Clean up
-			delete(requestContextStore, req)
+			requestContextStore.Delete(req)
 			break
 		}
 	}

--- a/router_test.go
+++ b/router_test.go
@@ -959,6 +959,23 @@ func isHandlersSliceDeepEqual(first []http.HandlerFunc, second []http.HandlerFun
 	return true
 }
 
+func TestLoadContext(t *testing.T) {
+	router := NewRouter()
+	router.Get("/", func(res http.ResponseWriter, req *http.Request) {
+		if cntxt := Context(req); cntxt == nil {
+			t.Error("Expected non-nil got nil")
+		}
+	})
+	server := httptest.NewServer(router)
+	defer server.Close()
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	if cntxt := Context(r); cntxt != nil {
+		t.Error("Expected nil got ", *cntxt)
+	}
+}
+
 func TestContextStoreRace(t *testing.T) {
 	router := NewRouter()
 	handler := func(res http.ResponseWriter, req *http.Request) {}


### PR DESCRIPTION
I have fixed a race condition and add a test for it.

I use `sync.Map` because I think go1.9 became generally available.
But if *router* supports go1.8 or earlier, `sync.Map` should replace with `golang.org/x/sync/syncmap.Map` or use map and `sync.Mutex`.